### PR TITLE
efi: use a wildcard section copy for final EFI generation

### DIFF
--- a/plugins/uefi/efi/generate_binary.sh
+++ b/plugins/uefi/efi/generate_binary.sh
@@ -8,9 +8,7 @@ $objcopy_cmd  -j .text \
               -j .data \
               -j .dynamic \
               -j .dynsym \
-              -j .rel \
-              -j .rela \
-              -j .reloc \
+              -j '.rel*' \
               $*
 
 if [ -n "${genpeimg_cmd}" ]; then


### PR DESCRIPTION
The GNU gold linker uses the section name `.rela.dyn` instead of
`.rela` for containing the relocation information. If this section
is not copied the EFI executable can crash.

Fixes #1530

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
