### PR TITLE
synaptics-mst: Skip self tests for systems with amdgpu

### DIFF
--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -41,7 +41,7 @@ fu_synaptics_mst_check_amdgpu_safe (GError **error)
 		if (g_str_has_prefix (lines[i], "amdgpu ")) {
 			g_set_error_literal (error,
 					     FWUPD_ERROR,
-					     FWUPD_ERROR_INTERNAL,
+					     FWUPD_ERROR_NOT_SUPPORTED,
 					     "amdgpu has known issues with synaptics_mst");
 			return FALSE;
 		}

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -68,6 +68,10 @@ fu_plugin_synaptics_mst_none_func (void)
 	g_assert_no_error (error);
 	g_assert (ret);
 	ret = fu_plugin_runner_startup (plugin, &error);
+	if (!ret && g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+		g_test_skip ("Skipping tests due to unsupported configuration");
+		return;
+	}
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -95,6 +99,10 @@ fu_plugin_synaptics_mst_tb16_func (void)
 	g_assert_no_error (error);
 	g_assert (ret);
 	ret = fu_plugin_runner_startup (plugin, &error);
+	if (!ret && g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+		g_test_skip ("Skipping tests due to unsupported configuration");
+		return;
+	}
 	g_assert_no_error (error);
 	g_assert (ret);
 


### PR DESCRIPTION
No need to fail these self tests when using amdgpu, just skip them.
Fixes unrelated issue found in #1183

Signed-off-by: Richard Hughes <richard@hughsie.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
